### PR TITLE
Fixes #17323 - Allow SSH provisioning with CR cert

### DIFF
--- a/app/assets/javascripts/foreman_azure/host_os_azure_selected.js
+++ b/app/assets/javascripts/foreman_azure/host_os_azure_selected.js
@@ -1,6 +1,6 @@
 function azure_image_selected() {
-  var url = $('#host_compute_attributes_image').attr('data-url');
-  var imageId = $('#host_compute_attributes_image').val();
+  var url = $('#host_compute_attributes_image_id').attr('data-url');
+  var imageId = $('#host_compute_attributes_image_id').val();
   var azure_locations = $('#azure_locations');
   var locations_spinner = $('#azure_locations_spinner');
   tfm.tools.showSpinner();
@@ -10,7 +10,7 @@ function azure_image_selected() {
     type:'get',
     url: url,
     complete: function(){
-      reloadOnAjaxComplete('#host_compute_attributes_image');
+      reloadOnAjaxComplete('#host_compute_attributes_image_id');
       locations_spinner.addClass('hide');
       tfm.tools.hideSpinner();
     },

--- a/app/controllers/foreman_azure/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_azure/concerns/hosts_controller_extensions.rb
@@ -2,7 +2,7 @@ module ForemanAzure
   module Concerns
     module HostsControllerExtensions
       def locations
-        if (azure_resource = Image.find_by_uuid(params[:image_id])).present?
+        if (azure_resource = Image.unscoped.find_by_uuid(params[:image_id])).present?
           render :json => azure_resource.compute_resource.
             image_locations(params[:image_id])
         else

--- a/app/helpers/azure_images_helper.rb
+++ b/app/helpers/azure_images_helper.rb
@@ -2,7 +2,7 @@ module AzureImagesHelper
   def select_azure_image(f, images)
     select_f(
       f,
-      :image,
+      :image_id,
       images,
       :uuid,
       :name,

--- a/app/models/concerns/fog_extensions/azure/server.rb
+++ b/app/models/concerns/fog_extensions/azure/server.rb
@@ -3,6 +3,8 @@ module FogExtensions
     module Server
       extend ActiveSupport::Concern
 
+      attr_accessor :image_id
+
       def to_s
         "#{vm_name}@#{cloud_service_name}"
       end

--- a/app/models/foreman_azure/azure.rb
+++ b/app/models/foreman_azure/azure.rb
@@ -45,7 +45,8 @@ module ForemanAzure
       args[:hostname] = args[:name]
       args[:vm_name] = args[:name].split('.').first
       args[:cloud_service_name] ||= args[:vm_name]
-      args[:vm_user] = Image.unscoped.find_by_uuid(args[:image]).username
+      args[:image] = args[:image_id]
+      args[:vm_user] = Image.unscoped.find_by_uuid(args[:image_id]).username
       args[:private_key_file] = url
       super(args)
     end

--- a/app/models/foreman_azure/concerns/ssh_provision_extensions.rb
+++ b/app/models/foreman_azure/concerns/ssh_provision_extensions.rb
@@ -1,0 +1,27 @@
+module ForemanAzure
+  module Concerns
+    module SSHProvisionExtensions
+      extend ActiveSupport::Concern
+
+      included do
+        alias_method_chain :setSSHWaitForResponse, :use_ssh_keys
+      end
+
+      def setSSHWaitForResponse_with_use_ssh_keys
+        if compute_resource.type == "ForemanAzure::Azure"
+          self.client = Foreman::Provision::SSH.new(
+            provision_ip,
+            image.username,
+            { :template => template_file.path,
+              :uuid => uuid,
+              :keys => [compute_resource.certificate_path] })
+        else
+          setSSHWaitForResponse_without_use_ssh_keys
+        end
+      rescue => e
+        failure _("Failed to login via SSH to %{name}: %{e}") %
+          { :name => name, :e => e }, e
+      end
+    end
+  end
+end

--- a/lib/foreman_azure/engine.rb
+++ b/lib/foreman_azure/engine.rb
@@ -48,6 +48,8 @@ module ForemanAzure
 
       ::HostsController.send :include,
         ForemanAzure::Concerns::HostsControllerExtensions
+      ::Host::Managed.send :include,
+        ForemanAzure::Concerns::SSHProvisionExtensions
     end
   end
 end


### PR DESCRIPTION
Problem:

SSH provisioning does not work. Only PXE provisioning is possible
through smart proxies in an Azure network.
The reason is that the setSSHWaitForResponse does not come with support
for using keys other than the foreman user ones.

Solution:

The certificate passed on to the Azure compute resource can be used to
SSH provision these machines as soon as they get a public IP.
The vm_user attribute that's passed on to Azure via fog will be the
username, and sudo is allowed in most Azure images.