### PR TITLE
Fixes #17635 - Enable network provisioning

### DIFF
--- a/app/models/foreman_azure/azure.rb
+++ b/app/models/foreman_azure/azure.rb
@@ -16,7 +16,7 @@ module ForemanAzure
     end
 
     def capabilities
-      [:image]
+      [:build, :image]
     end
 
     def self.model_name


### PR DESCRIPTION
The compute resource was missing the :build capability to do
network provisioning. After that's set, Foreman core takes care of the
rest.